### PR TITLE
Ignore all build artifacts

### DIFF
--- a/software/.gitignore
+++ b/software/.gitignore
@@ -1,9 +1,4 @@
 infnoise
-KeccakF-1600-reference.o
-daemon.o
-healthcheck.o
-infnoise
-infnoise.o
-libinfnoise.a
-libinfnoise.o
-libinfnoise.so
+*.a
+*.o
+*.so


### PR DESCRIPTION
Instead of listing .o etc. files by name, match them using wildcards.

Signed-off-by: Stephen Kitt <steve@sk2.org>